### PR TITLE
DatePickerActivity needs to be public

### DIFF
--- a/app/src/main/java/com/example/simpleres/DatePickerActivity.java
+++ b/app/src/main/java/com/example/simpleres/DatePickerActivity.java
@@ -13,7 +13,7 @@ import androidx.fragment.app.DialogFragment;
 import java.util.Calendar;
 import java.util.Objects;
 
-class DatePickerActivity extends DialogFragment {
+public class DatePickerActivity extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {


### PR DESCRIPTION
Accidentally changed access specifier to default but it needs to be public 